### PR TITLE
Compare value with Unlimited using OrdinalIgnoreCase option

### DIFF
--- a/DotNet/Curly/Binding/DefaultCurlyMethodBinder.cs
+++ b/DotNet/Curly/Binding/DefaultCurlyMethodBinder.cs
@@ -183,7 +183,7 @@ namespace Curly.Binding
                 return CurlyDsl.ParseDateOrInvalid(o, DateTime.MinValue);
             }
 
-            if (CurlyDsl.Unlimited.Equals(o))
+            if (CurlyDsl.Unlimited.Equals(o, StringComparison.OrdinalIgnoreCase))
             {
                 src = Int32.MaxValue;
             }


### PR DESCRIPTION
Make unlimited value case insensitive.
For instance: when dsl method max is used and value is Unlimited, it does not recognize it like unlimited value and as result we will get incorrect result. 
Using option StringComparison.OrdinalIgnoreCase when equal two values fixes this issue